### PR TITLE
use a numerical version in META (_NUM strips leading v)

### DIFF
--- a/pkg/META
+++ b/pkg/META
@@ -1,5 +1,5 @@
 description = "Make interactive text-based user-interfaces in OCaml"
-version = "%%VERSION%%"
+version = "%%VERSION_NUM%%"
 requires = "grenier.trope"
 archive(byte) = "inuit.cma"
 archive(native) = "inuit.cmxa"


### PR DESCRIPTION
since the 0.1 release is `v0.1` in META now...